### PR TITLE
fix: i2c_smbus_write_byte always sends zero

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,12 +505,11 @@ pub fn i2c_smbus_read_byte(fd: RawFd) -> io::Result<u8> {
 
 pub fn i2c_smbus_write_byte(fd: RawFd, value: u8) -> io::Result<()> {
     unsafe {
-        let mut data = i2c_smbus_data::from_byte(value);
         let mut ioctl = i2c_smbus_ioctl_data {
             read_write: SmbusReadWrite::Write,
-            command: 0,
+            command: value,
             size: SmbusTransaction::Byte,
-            data: &mut data,
+            data: ptr::null_mut(),
         };
         i2c_smbus(fd, &mut ioctl)
     }


### PR DESCRIPTION
In case of `i2c_smbus_write_byte` the single data byte should be passed in the command field instead of the data field. Without this patch the function always send a zero value.

As a reference here's the matching function from i2c-tools: https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/tree/lib/smbus.c?id=d8bc1f1ff4b00a6bd988aa114100ae9b787f50d8#n65

I came across this bug while trying to trigger a humidity measurement on the HDC1010 sensor. See figure 12 of the [datasheet](https://www.ti.com/lit/ds/symlink/hdc1010.pdf) for details.